### PR TITLE
Types for the public api are all over the place

### DIFF
--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -3,24 +3,10 @@
 //! No authentication is required for this section of the library.
 pub mod public_api;
 
-use std::error::Error;
-use serde::{Deserialize, Serialize};
-
-/// CoinSpot's api documentation says that any bad response will fall into this format.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct CoinSpotBadResponse {
-    pub status: String,
-    pub message: String,
-}
-
-/// This enum encompasses the expected responses from the CoinSpot api. It uses a generic type enable easier pattern matching.
-pub enum CoinSpotResponse<T> {
-    Ok(T),
-    Bad(CoinSpotBadResponse)
-}
-
-/// This is an alias of Rust's Result type, the generic passed in will map to the Ok type in CoinSpotResponse.
-pub type CoinSpotResult<T> = Result<CoinSpotResponse<T>, Box<dyn Error>>;
+/// Holds all the types used by the v2 sdk.
+/// Some responses have overlaping response interfaces.
+/// This is reflected in types as compatible interfaces share types.
+pub mod types;
 
 /// The main entry point for the public API methods.
 /// All methods are static.

--- a/src/v2/public_api/latest_buy_price.rs
+++ b/src/v2/public_api/latest_buy_price.rs
@@ -1,22 +1,21 @@
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
 
-use crate::v2::{CoinSpotBadResponse, CoinSpotPublic, CoinSpotResponse, CoinSpotResult};
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LatestBuyPrice {
-    pub status: String,
-    pub message: String,
-    pub rate: String,
-    pub market: String,
-}
+use crate::v2::{
+    CoinSpotPublic,
+    types::{
+        CoinSpotBadResponse,
+        CoinSpotResponse,
+        CoinSpotResult,
+        LatestActionPrice
+    }
+};
 
 impl CoinSpotPublic {
 
     /// Used to get the latest buy price of a specific coin.
     /// CoinSpot's API also throws a 400 error for invalid markets.
     /// This 400 error will return a CoinSpotResponse::Bad response
-    pub async fn latest_buy_price(coin_symbol: &str) -> CoinSpotResult<LatestBuyPrice>{
+    pub async fn latest_buy_price(coin_symbol: &str) -> CoinSpotResult<LatestActionPrice>{
         let url = format!("https://www.coinspot.com.au/pubapi/v2/buyprice/{}", coin_symbol);
         println!("{:?}", &url);
         let res = reqwest::get(
@@ -27,7 +26,7 @@ impl CoinSpotPublic {
             StatusCode::OK => {
                 let text = res.text().await?;
                 println!("{:?}", &text);
-                let json: LatestBuyPrice = serde_json::from_str(&text)?;
+                let json: LatestActionPrice = serde_json::from_str(&text)?;
                 return Ok(
                     CoinSpotResponse::Ok(json)
                 )

--- a/src/v2/public_api/latest_buy_price_market.rs
+++ b/src/v2/public_api/latest_buy_price_market.rs
@@ -1,7 +1,14 @@
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use crate::v2::{CoinSpotBadResponse, CoinSpotPublic, CoinSpotResponse, CoinSpotResult};
+use crate::v2::{
+    CoinSpotPublic,
+    types::{
+        CoinSpotBadResponse,
+        CoinSpotResponse,
+        CoinSpotResult,
+    }
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LatestBuyPrice {

--- a/src/v2/public_api/latest_buy_price_market.rs
+++ b/src/v2/public_api/latest_buy_price_market.rs
@@ -1,5 +1,4 @@
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
 
 use crate::v2::{
     CoinSpotPublic,
@@ -7,23 +6,16 @@ use crate::v2::{
         CoinSpotBadResponse,
         CoinSpotResponse,
         CoinSpotResult,
+        LatestActionPrice
     }
 };
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LatestBuyPrice {
-    pub status: String,
-    pub message: String,
-    pub rate: String,
-    pub market: String,
-}
 
 impl CoinSpotPublic {
 
     /// Used to get the latest buy price of a specific coin.
     /// CoinSpot's API also throws a 400 error for invalid markets.
     /// This 400 error will return a CoinSpotResponse::Bad response
-    pub async fn latest_buy_price_market(coin_symbol: &str, market: &str) -> CoinSpotResult<LatestBuyPrice>{
+    pub async fn latest_buy_price_market(coin_symbol: &str, market: &str) -> CoinSpotResult<LatestActionPrice>{
         let url = format!("https://www.coinspot.com.au/pubapi/v2/buyprice/{}/{}", coin_symbol, market);
         println!("{:?}", &url);
         let res = reqwest::get(
@@ -34,7 +26,7 @@ impl CoinSpotPublic {
             StatusCode::OK => {
                 let text = res.text().await?;
                 println!("{:?}", &text);
-                let json: LatestBuyPrice = serde_json::from_str(&text)?;
+                let json: LatestActionPrice = serde_json::from_str(&text)?;
                 return Ok(
                     CoinSpotResponse::Ok(json)
                 )
@@ -63,7 +55,7 @@ mod tests {
     #[tokio::test]
     async fn test_latest_buy_price() {
     
-        let result: CoinSpotResponse<LatestBuyPrice>;
+        let result: CoinSpotResponse<LatestActionPrice>;
         result = CoinSpotPublic::latest_buy_price_market("btc", "usdt")
         .await
         .unwrap();

--- a/src/v2/public_api/latest_coin_price.rs
+++ b/src/v2/public_api/latest_coin_price.rs
@@ -1,7 +1,13 @@
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use crate::v2::{CoinSpotPublic, CoinSpotResponse, CoinSpotResult};
+use crate::v2::{
+    CoinSpotPublic,
+    types::{
+        CoinSpotResponse,
+        CoinSpotResult,
+    }
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Prices {

--- a/src/v2/public_api/latest_coin_price.rs
+++ b/src/v2/public_api/latest_coin_price.rs
@@ -1,25 +1,12 @@
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
-
 use crate::v2::{
     CoinSpotPublic,
     types::{
         CoinSpotResponse,
         CoinSpotResult,
+        LatestPrice
     }
 };
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Prices {
-    pub bid: String,
-    pub ask: String,
-    pub last: String
-}
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LatestCoinPriceResponse {
-    pub status: String,
-    pub prices: Prices
-}
 
 impl CoinSpotPublic {
 
@@ -27,7 +14,7 @@ impl CoinSpotPublic {
     /// CoinSpot's API does not handle invalid coins, neither does this sdk.
     /// This method will throw a serde_json parse error in the event of an invalid coin input. 
     /// 
-    pub async fn latest_coin_price(coin_symbol: &str) -> CoinSpotResult<LatestCoinPriceResponse>{
+    pub async fn latest_coin_price(coin_symbol: &str) -> CoinSpotResult<LatestPrice>{
         let url = format!("https://www.coinspot.com.au/pubapi/v2/latest/{}", coin_symbol);
         println!("{:?}", &url);
         let res = reqwest::get(
@@ -38,7 +25,7 @@ impl CoinSpotPublic {
             StatusCode::OK => {
                 let text = res.text().await?;
                 println!("{:?}", &text);
-                let json: LatestCoinPriceResponse = serde_json::from_str(&text)?;
+                let json: LatestPrice = serde_json::from_str(&text)?;
                 return Ok(
                     CoinSpotResponse::Ok(json)
                 )

--- a/src/v2/public_api/latest_coin_price_market.rs
+++ b/src/v2/public_api/latest_coin_price_market.rs
@@ -1,32 +1,19 @@
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
-
 use crate::v2::{
     CoinSpotPublic,
     types::{
         CoinSpotResponse,
         CoinSpotResult,
+        LatestPrice
     }
 };
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Prices {
-    pub bid: String,
-    pub ask: String,
-    pub last: String
-}
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LatestCoinMarketPriceResponse {
-    pub status: String,
-    pub prices: Prices
-}
 
 impl CoinSpotPublic {
 
     /// Used to get the latest prices of a specific coin, on a specific market.
     /// CoinSpot's API also throws a 404 error for invalid markets, this 404 does not return the error response you might expect.
     /// Therefore, neither does this sdk.
-    pub async fn latest_coin_price_market(coin_symbol: &str, market: &str) -> CoinSpotResult<LatestCoinMarketPriceResponse>{
+    pub async fn latest_coin_price_market(coin_symbol: &str, market: &str) -> CoinSpotResult<LatestPrice>{
         let url = format!("https://www.coinspot.com.au/pubapi/v2/latest/{}/{}", coin_symbol, market);
         println!("{:?}", &url);
         let res = reqwest::get(
@@ -37,7 +24,7 @@ impl CoinSpotPublic {
             StatusCode::OK => {
                 let text = res.text().await?;
                 println!("{:?}", &text);
-                let json: LatestCoinMarketPriceResponse = serde_json::from_str(&text)?;
+                let json: LatestPrice = serde_json::from_str(&text)?;
                 return Ok(
                     CoinSpotResponse::Ok(json)
                 )

--- a/src/v2/public_api/latest_coin_price_market.rs
+++ b/src/v2/public_api/latest_coin_price_market.rs
@@ -1,7 +1,13 @@
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use crate::v2::{CoinSpotPublic, CoinSpotResponse, CoinSpotResult};
+use crate::v2::{
+    CoinSpotPublic,
+    types::{
+        CoinSpotResponse,
+        CoinSpotResult,
+    }
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Prices {

--- a/src/v2/public_api/latest_prices.rs
+++ b/src/v2/public_api/latest_prices.rs
@@ -1,7 +1,14 @@
 use std::collections::HashMap;
-use crate::v2::{CoinSpotBadResponse, CoinSpotPublic, CoinSpotResponse, CoinSpotResult};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use crate::v2::{
+    CoinSpotPublic,
+    types::{
+        CoinSpotBadResponse,
+        CoinSpotResponse,
+        CoinSpotResult,
+    }
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Price {

--- a/src/v2/public_api/latest_prices.rs
+++ b/src/v2/public_api/latest_prices.rs
@@ -1,41 +1,25 @@
-use std::collections::HashMap;
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
 use crate::v2::{
     CoinSpotPublic,
     types::{
         CoinSpotBadResponse,
         CoinSpotResponse,
         CoinSpotResult,
+        LatestPrices
     }
 };
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Price {
-    pub bid: String,
-    pub ask: String,
-    pub last: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LatestPricesResponse {
-    pub status: String,
-    // At this stage, event though the API documentation states this is here on a successful request, it is not.
-    // message: String,
-    pub prices: HashMap<String, Price>
-}
 
 impl CoinSpotPublic {
 
     /// <https://www.coinspot.com.au/v2/api#latestprices>
     /// 
     /// Worth noting that even though the docs specify message: "ok" to exist on a successful request, it doesn't exist.
-    pub async fn latest_prices() -> CoinSpotResult<LatestPricesResponse> {
+    pub async fn latest_prices() -> CoinSpotResult<LatestPrices> {
         let res = reqwest::get("https://www.coinspot.com.au/pubapi/v2/latest").await?;
 
         match res.status() {
             StatusCode::OK => {
-                let res_json: LatestPricesResponse = serde_json::from_str(&res.text().await?)?;
+                let res_json: LatestPrices = serde_json::from_str(&res.text().await?)?;
                 return Ok(
                     CoinSpotResponse::Ok(res_json)
                 )
@@ -60,7 +44,7 @@ mod tests {
     #[tokio::test]
     async fn test_latest_prices() {
     
-        let result: CoinSpotResponse<LatestPricesResponse> = CoinSpotPublic::latest_prices().await.unwrap();
+        let result: CoinSpotResponse<LatestPrices> = CoinSpotPublic::latest_prices().await.unwrap();
 
         match result {
             CoinSpotResponse::Ok(res) => {

--- a/src/v2/types/mod.rs
+++ b/src/v2/types/mod.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+
+/// CoinSpot's api documentation says that any bad response will fall into this format.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CoinSpotBadResponse {
+    pub status: String,
+    pub message: String,
+}
+
+/// This enum encompasses the expected responses from the CoinSpot api. It uses a generic type enable easier pattern matching.
+pub enum CoinSpotResponse<T> {
+    Ok(T),
+    Bad(CoinSpotBadResponse)
+}
+
+/// This is an alias of Rust's Result type, the generic passed in will map to the Ok type in CoinSpotResponse.
+pub type CoinSpotResult<T> = Result<CoinSpotResponse<T>, Box<dyn Error>>;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct LatestActionPrice {
+    pub status: String,
+    pub message: String,
+    pub rate: String,
+    pub market: String
+}

--- a/src/v2/types/mod.rs
+++ b/src/v2/types/mod.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::error::Error;
+use std::{collections::HashMap, error::Error};
 
 /// CoinSpot's api documentation says that any bad response will fall into this format.
 #[derive(Serialize, Deserialize, Debug)]
@@ -22,6 +22,12 @@ pub struct Price {
     pub bid: String,
     pub ask: String,
     pub last: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct LatestPrices {
+    pub status: String,
+    pub prices: HashMap<String, Price>
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/v2/types/mod.rs
+++ b/src/v2/types/mod.rs
@@ -18,6 +18,19 @@ pub enum CoinSpotResponse<T> {
 pub type CoinSpotResult<T> = Result<CoinSpotResponse<T>, Box<dyn Error>>;
 
 #[derive(Deserialize, Serialize, Debug)]
+pub struct Price {
+    pub bid: String,
+    pub ask: String,
+    pub last: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct LatestPrice {
+    pub status: String,
+    pub prices: Price
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 pub struct LatestActionPrice {
     pub status: String,
     pub message: String,


### PR DESCRIPTION
Types are now consolidated inside of a types module and used repeatedly through the sdk.